### PR TITLE
add missing extern keyword to fix multiple definition

### DIFF
--- a/gap/src/memmgr.h
+++ b/gap/src/memmgr.h
@@ -326,7 +326,7 @@ typedef struct {
  *  data when the code section or operation is complete.
  */
 
-UInt        bagCodeMarker;
+extern  UInt        bagCodeMarker;
 
 /* 
 **  With the definition of BagStruct_t we don't assume aspecific order/place for

--- a/gap/src/scanner.h
+++ b/gap/src/scanner.h
@@ -413,7 +413,7 @@ typedef struct {
     Bag		hdList;
 }       TypOutputFile;
 
-TypOutputFile   * Output;
+extern TypOutputFile   * Output;
 
 /****************************************************************************
 **


### PR DESCRIPTION
Spiral 8.2.0 and master currently fail to compile on Linux with cmake 3.18.4 and GCC 10.2.1, because the global symbols `bagCodeMarker` and `Output` are not declared `extern`:

```
...
[ 95%] Building C object gap/src/CMakeFiles/gap.dir/function.c.o
[ 96%] Building C object gap/src/CMakeFiles/gap.dir/coding.c.o
[ 98%] Building C object gap/src/CMakeFiles/gap.dir/GapUtils.c.o
[100%] Linking C executable gap
/usr/bin/ld: CMakeFiles/gap.dir/memmgr.c.o:(.bss+0x54438): multiple definition of `bagCodeMarker'; CMakeFiles/gap.dir/gap.c.o:(.bss+0x60): first defined here
/usr/bin/ld: CMakeFiles/gap.dir/memmgr.c.o:(.bss+0x54440): multiple definition of `Output'; CMakeFiles/gap.dir/gap.c.o:(.bss+0x58): first defined here
/usr/bin/ld: CMakeFiles/gap.dir/scanner.c.o:(.bss+0xcd48): multiple definition of `Output'; CMakeFiles/gap.dir/gap.c.o:(.bss+0x58): first defined here
/usr/bin/ld: CMakeFiles/gap.dir/scanner.c.o:(.bss+0xcd50): multiple definition of `bagCodeMarker'; CMakeFiles/gap.dir/gap.c.o:(.bss+0x60): first defined here
... repeats 30+ times ...
```

I added the missing `extern`, fixing the compilation issue and passing all tests.