### PR TITLE
Update release version & release notes (#66)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,11 @@ cmake_minimum_required(VERSION 3.14)
 set(CMAKE_BUILD_TYPE Release  CACHE STRING "Debug, Release, RelWithDebInfo, MinSizeRel")
 
 project(SPIRAL
-        VERSION 8.3.1
+        VERSION 8.4.0
         DESCRIPTION "SPIRAL Project"
         LANGUAGES C CXX)
 
-set(PROJECT_VERSION_TAG "d03")
+set(PROJECT_VERSION_TAG "-release")
 
 ##  Prevent building directly into the source tree
 string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" SPIRAL_COMPILE_INPLACE)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,65 @@
+## Release Notes for Spiral Version 8.4.0
+
+### Introduction
+
+These release notes for Spiral 8.4.0 provide an overview of the release and
+document any known issues.  For details of the changes applied since the last
+release, please see the **Change Summary** below.
+
+### Supported Platforms
+
+Spiral is supported on Windows, Linux, and MacOS.
+
+Spiral is configured using **cmake** and is expected to run on most UNIX-like systems.
+
+See the [**README**](./README.md) file for more information on how to build for
+a specific platform.
+
+### Get Spiral Version 8.4.0
+
+You can download the lastest release from:
+
+https://github.com/spiral-software/spiral-software.git
+
+## Change Summary
+
+### New Features
+
+#### General Cleanup
+* Numerous changes were made to clean up some old code, simplifying (removing
+when possible), relying on standard library functions, and providing a single
+method to perform a function instead of supporting multiple methods.
+* Reduced and simplified the number of environment variables that were (or could
+be) set to control Spiral's operation. 
+* Removed [old, deprecated, or unused] code.
+
+#### CUDA
+Several examples (also doubling as tests) added to demonstrate CUDA code generation and testing.
+
+#### Profiler
+Several enhancements to improve the performance of the profiler.
+Improved handling of matrices returned by profiler, added ability to specify
+upper/lower corners of a sub-matrix (test or verify a portion of a large
+matrix). 
+Get a list of the best timed ruletrees
+In addition, cmake is now the standard build tools across all platforms when
+profiling Spiral generated code. 
+
+### Bug Fixes
+
+* Fixed / improved several minor issues for profiler
+
+### Known Issues
+
+None at present.
+
+## License
+
+Spiral is open source software licensed under the terms of the Simplified BSD
+License (see the [**LICENSE**](./LICENSE) file for the full text). 
+
+----------------------------------------------------------------------------------------------------
+
 ## Release Notes for Spiral Version 8.3.0
 
 ### Introduction


### PR DESCRIPTION
* Set master branch for doc updates (was develop)

* build out-of-source; in-source fails on bridges

* Add CUDA examples to the user manual

* rebuild docs on push to develop or master branch

* look in develop branch for updates

* Convert all profiler targets to use CMake

* Convert all profiler targets to use CMake & rm obsolete Makefiles

* updates - use cmake for all targets

* adjust libraries and compiler settings (adjusts for OpenMP) / CUDA

* manage additional flags & libraries for different targets

* Don't add switches/libraries for OpenMP on MAC

* test cmake_host_apple

* fix windows command files, tweak makelist for no openmp on mac

* Make a bin folder for install purposes; for now just populate with startup scripts

* rework generation of output file

* Bump release version, update release notes