### PR TITLE
Updated SPIRAL to work with CUDA 13.0.

### DIFF
--- a/profiler/targets/common/CMakeLists.txt
+++ b/profiler/targets/common/CMakeLists.txt
@@ -130,7 +130,7 @@ else ()
 endif ()
 
 if ( ${SUFFIX} STREQUAL "cu" )
-    set ( CMAKE_CUDA_ARCHITECTURES 60 61 62 70 72 75 80)
+    set ( CMAKE_CUDA_ARCHITECTURES native) ## WAS 60 61 62 70 72 75 80
 endif ()
 
 add_executable		     ( ${PROJECT} ${SOURCES} )

--- a/profiler/targets/include/helper_cuda.h
+++ b/profiler/targets/include/helper_cuda.h
@@ -122,14 +122,14 @@ static const char *_cudaGetErrorEnum(cufftResult error) {
     case CUFFT_UNALIGNED_DATA:
       return "CUFFT_UNALIGNED_DATA";
 
-    case CUFFT_INCOMPLETE_PARAMETER_LIST:
-      return "CUFFT_INCOMPLETE_PARAMETER_LIST";
+      //    case CUFFT_INCOMPLETE_PARAMETER_LIST:
+      //      return "CUFFT_INCOMPLETE_PARAMETER_LIST";
 
     case CUFFT_INVALID_DEVICE:
       return "CUFFT_INVALID_DEVICE";
 
-    case CUFFT_PARSE_ERROR:
-      return "CUFFT_PARSE_ERROR";
+      //    case CUFFT_PARSE_ERROR:
+      //      return "CUFFT_PARSE_ERROR";
 
     case CUFFT_NO_WORKSPACE:
       return "CUFFT_NO_WORKSPACE";
@@ -137,8 +137,8 @@ static const char *_cudaGetErrorEnum(cufftResult error) {
     case CUFFT_NOT_IMPLEMENTED:
       return "CUFFT_NOT_IMPLEMENTED";
 
-    case CUFFT_LICENSE_ERROR:
-      return "CUFFT_LICENSE_ERROR";
+      //    case CUFFT_LICENSE_ERROR:
+      //      return "CUFFT_LICENSE_ERROR";
 
     case CUFFT_NOT_SUPPORTED:
       return "CUFFT_NOT_SUPPORTED";
@@ -714,7 +714,10 @@ inline int gpuDeviceInit(int devID) {
   cudaDeviceProp deviceProp;
   checkCudaErrors(cudaGetDeviceProperties(&deviceProp, devID));
 
-  if (deviceProp.computeMode == cudaComputeModeProhibited) {
+  int computeMode;
+  cudaDeviceGetAttribute(&computeMode, cudaDevAttrComputeMode, devID);
+  // if (deviceProp.computeMode == cudaComputeModeProhibited)
+  if (computeMode == cudaComputeModeProhibited) {
     fprintf(stderr,
             "Error: device is running in <Compute Mode "
             "Prohibited>, no threads can use cudaSetDevice().\n");
@@ -758,7 +761,10 @@ inline int gpuGetMaxGflopsDeviceId() {
 
     // If this GPU is not running on Compute Mode prohibited,
     // then we can add it to the list
-    if (deviceProp.computeMode != cudaComputeModeProhibited) {
+    int computeModeCurrent;
+    cudaDeviceGetAttribute(&computeModeCurrent, cudaDevAttrComputeMode, current_device);
+    // if (deviceProp.computeMode != cudaComputeModeProhibited)
+    if (computeModeCurrent != cudaComputeModeProhibited) {
       if (deviceProp.major == 9999 && deviceProp.minor == 9999) {
         sm_per_multiproc = 1;
       } else {
@@ -766,8 +772,11 @@ inline int gpuGetMaxGflopsDeviceId() {
             _ConvertSMVer2Cores(deviceProp.major, deviceProp.minor);
       }
 
+      int clockRate;
+      cudaDeviceGetAttribute(&clockRate, cudaDevAttrClockRate, current_device);
       uint64_t compute_perf = (uint64_t)deviceProp.multiProcessorCount *
-                              sm_per_multiproc * deviceProp.clockRate;
+        // sm_per_multiproc * deviceProp.clockRate;
+        sm_per_multiproc * clockRate;
 
       if (compute_perf > max_compute_perf) {
         max_compute_perf = compute_perf;
@@ -841,8 +850,11 @@ inline int findIntegratedGPU() {
 
     // If GPU is integrated and is not running on Compute Mode prohibited,
     // then cuda can map to GLES resource
+    int computeModeCurrent;
+    cudaDeviceGetAttribute(&computeModeCurrent, cudaDevAttrComputeMode, current_device);
     if (deviceProp.integrated &&
-        (deviceProp.computeMode != cudaComputeModeProhibited)) {
+        // (deviceProp.computeMode != cudaComputeModeProhibited))
+        (computeModeCurrent != cudaComputeModeProhibited)) {
       checkCudaErrors(cudaSetDevice(current_device));
       checkCudaErrors(cudaGetDeviceProperties(&deviceProp, current_device));
       printf("GPU Device %d: \"%s\" with compute capability %d.%d\n\n",

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -52,7 +52,7 @@ if ( ${_codegen} STREQUAL "GPU" )
     endif ()
 
     ##  set ( CMAKE_CUDA_ARCHITECTURES 60 61 62 70 72 75 )
-    set ( CMAKE_CUDA_ARCHITECTURES 70 )
+    set ( CMAKE_CUDA_ARCHITECTURES native ) ## WAS 70
     set ( GPU_EXTRAS _CUDAGEN )
 endif ()
 


### PR DESCRIPTION
Working in branch "`develop`".

When I try to build SPIRAL, "`cmake ..`" includes this output:
```
-- CUDA Toolkit Found : Version = 13.2.78
-- The CUDA compiler identification is NVIDIA 13.2.78
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /usr/local/cuda/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
```
Then "`make install`" fails:
```
[ 96%] Building CUDA object support/CMakeFiles/checkforGpu.dir/checkforGpu.cu.o
nvcc fatal   : Unsupported gpu architecture 'compute_70'
make[2]: *** [support/CMakeFiles/checkforGpu.dir/build.make:77: support/CMakeFiles/checkforGpu.dir/checkforGpu.cu.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:331: support/CMakeFiles/checkforGpu.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
This is because the gpu architecture on my workstation is compute_120;
it is a NVIDIA RTX 5080 GPU.

MY CHANGE: in `support/CMakeLists.txt`, changed
`set ( CMAKE_CUDA_ARCHITECTURES 70 )`
to
`set ( CMAKE_CUDA_ARCHITECTURES native )`
And in `profiler/targets/common/CMakeLists.txt`, changed
`set ( CMAKE_CUDA_ARCHITECTURES 60 61 62 70 72 75 80)`
to
`set ( CMAKE_CUDA_ARCHITECTURES native)`

Then, starting over, "`make install`" fails in a different way:
```
[ 96%] Building CUDA object support/CMakeFiles/checkforGpu.dir/checkforGpu.cu.o
/home/petermc/FFTX/spiral-software-mine/profiler/targets/include/helper_cuda.h(717): error: class "cudaDeviceProp" has no member "computeMode"
    if (deviceProp.computeMode == cudaComputeModeProhibited) {
                   ^

/home/petermc/FFTX/spiral-software-mine/profiler/targets/include/helper_cuda.h(761): error: class "cudaDeviceProp" has no member "computeMode"
      if (deviceProp.computeMode != cudaComputeModeProhibited) {
                     ^

/home/petermc/FFTX/spiral-software-mine/profiler/targets/include/helper_cuda.h(770): error: class "cudaDeviceProp" has no member "clockRate"
                                sm_per_multiproc * deviceProp.clockRate;
                                                              ^

/home/petermc/FFTX/spiral-software-mine/profiler/targets/include/helper_cuda.h(845): error: class "cudaDeviceProp" has no member "computeMode"
          (deviceProp.computeMode != cudaComputeModeProhibited)) {
                      ^

4 errors detected in the compilation of "/home/petermc/FFTX/spiral-software-mine/support/checkforGpu.cu".
make[2]: *** [support/CMakeFiles/checkforGpu.dir/build.make:77: support/CMakeFiles/checkforGpu.dir/checkforGpu.cu.o] Error 2
make[1]: *** [CMakeFiles/Makefile2:331: support/CMakeFiles/checkforGpu.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
MY CHANGE: updated `profiler/targets/include/helper_cuda.h`
to work with the updated `cudaDeviceProp` struct in CUDA 13.0.

MY CHANGE: also updated `profiler/targets/include/helper_cuda.h`
to remove `CUFFT_INCOMPLETE_PARAMETER_LIST`, `CUFFT_PARSE_ERROR`, and
`CUFFT_LICENSE_ERROR`, which are no longer recognized in CUDA 13.0.
